### PR TITLE
Hide internal values to force runtime safety checks

### DIFF
--- a/src/redisparser.nim
+++ b/src/redisparser.nim
@@ -1,39 +1,48 @@
 import strformat, strutils, hashes, net,  strutils
 
 const
-  CRLF = "\r\n"
-  CRLF_LEN = len(CRLF)
-  REDIS_NIL = "\0\0"
+  CRLF* = "\r\n"
+  CRLF_LEN* = len(CRLF)
 
 type
+  RespError* = object of IOError
+  TypeError* = object of IOError
+
   ValueKind* = enum
     vkStr, vkError, vkInt, vkBulkStr, vkArray
 
   RedisValue* = ref object
-    case kind*: ValueKind
-    of vkStr: s*: string
-    of vkError : err*: string
-    of vkInt: i*: int
-    of vkBulkStr: bs*: string
-    of vkArray: l*: seq[RedisValue]
+    case kind: ValueKind
+    of vkStr: s: string
+    of vkError : err: string
+    of vkInt: i: int
+    of vkBulkStr: bs: string
+    of vkArray: l: seq[RedisValue]
 
-proc `$`*(obj: RedisValue): string =
-  case obj.kind
-    of vkStr : return  fmt"{$(obj.s)}"
-    of vkBulkStr: return fmt"{$(obj.bs)}"
-    of vkInt : return fmt"{$(obj.i)}"
-    of vkArray: return fmt"{$(obj.l)}"
-    of vkError: return fmt"{$(obj.err)}"
+proc `$`*(v: RedisValue): string =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  case v.kind
+    of vkStr : return v.s
+    of vkBulkStr: return v.bs
+    of vkInt : return $v.i
+    of vkArray: return $v.l
+    of vkError: return v.err
 
-proc hash*(obj: RedisValue): Hash =
-  case obj.kind
-  of vkStr : !$(hash(obj.s))
-  of vkBulkStr: !$(hash(obj.bs))
-  of vkInt : !$(hash(obj.i))
-  of vkArray: !$(hash(obj.l))
-  of vkError: !$(hash(obj.err))
+proc hash*(v: RedisValue): Hash =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  var h: Hash = 0
+  h = h !& hash(v.kind)
+  case v.kind
+  of vkStr : h = h !& hash(v.s)
+  of vkBulkStr: h = h !& hash(v.bs)
+  of vkInt : h = h !&  hash(v.i)
+  of vkArray: h = h !& hash(v.l)
+  of vkError: h = h !& hash(v.err)
+  result = !$h
 
-proc `==`* (a, b: RedisValue): bool =
+proc `==`*(a, b: RedisValue): bool =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true
@@ -53,9 +62,91 @@ proc `==`* (a, b: RedisValue): bool =
     of vkError:
       return a.err == b.err
 
+proc len*(v: RedisValue): int =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  case v.kind
+  of vkStr:
+    result = v.s.len
+  of vkError:
+    result = v.err.len
+  of vkBulkStr:
+    result = v.bs.len
+  of vkArray:
+    result = v.l.len
+  else:
+    raise newException(TypeError, fmt"Invalid data type for `len`: {v.kind}")
 
+proc `[]`*(v: RedisValue, idx: int): RedisValue =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  if v.kind != vkArray:
+    raise newException(TypeError, fmt"Array expected but got {v.kind}")
+  result = v.l[idx]
 
-proc encode*(v: RedisValue) : string
+iterator items*(v: RedisValue): RedisValue =
+  if v.kind == vkArray:
+    for i in 0..<v.l.len:
+      yield v.l[0]
+
+proc newRedisString*(input: string = ""): RedisValue {.inline.} = RedisValue(kind: vkStr, s: input)
+proc newRedisError*(input: string = ""): RedisValue {.inline.} = RedisValue(kind: vkError, err: input)
+proc newRedisInt*(input: SomeInteger = 0): RedisValue {.inline.} = RedisValue(kind: vkInt, i: input)
+proc newRedisBulkString*(input: string = ""): RedisValue {.inline.} = RedisValue(kind: vkBulkStr, bs: input)
+proc newRedisArray*(input: seq[RedisValue] = @[]): RedisValue {.inline.} = RedisValue(kind: vkArray, l: input)
+
+proc isString*(v: RedisValue): bool {.inline.} =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  v.kind == vkStr
+proc isError*(v: RedisValue): bool {.inline.} =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  v.kind == vkError
+proc isInteger*(v: RedisValue): bool {.inline.} =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  v.kind == vkInt
+proc isBulkString*(v: RedisValue): bool {.inline.} =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  v.kind == vkBulkStr
+proc isArray*(v: RedisValue): bool {.inline.} =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  v.kind == vkArray
+
+proc getStr*(v: RedisValue): string =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  if v.isString():
+    return v.s
+  elif v.isBulkString():
+    return v.bs
+  raise newException(TypeError, fmt"Value is not a string or bulk string, got kind: {v.kind}")
+
+proc getError*(v: RedisValue): string =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  if v.isError():
+    return v.err
+  raise newException(TypeError, fmt"Value is not an error, got kind: {v.kind}")
+
+proc getInt*(v: RedisValue): int =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  if v.isInteger():
+    return v.i
+  raise newException(TypeError, fmt"Value is not an interger, got kind: {v.kind}")
+
+proc getItems*(v: RedisValue): seq[RedisValue] =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
+  if v.isArray():
+    return v.l
+  raise newException(TypeError, fmt"Value is not an array, got kind: {v.kind}")
+
+proc encode*(v: RedisValue) : string {.gcsafe.}
 proc encodeStr(v: RedisValue) : string =
   return fmt"+{v.s}{CRLF}"
 
@@ -76,6 +167,8 @@ proc encodeArray(v: RedisValue): string =
   return res
 
 proc encode*(v: RedisValue) : string =
+  if v.isNil:
+    raise newException(ValueError, "Redis value is nil")
   case v.kind
   of vkStr: return encodeStr(v)
   of vkInt:    return encodeInt(v)
@@ -99,13 +192,17 @@ proc decodeBulkStr(s: string, pos: var int): RedisValue =
     crlfPos = s.find(CRLF, pos)
     bulkLen = parseInt(s[pos..<crlfPos])
   pos = crlfPos + CRLF_LEN
-  result = RedisValue(kind:vkBulkStr)
   if bulkLen == -1:
-    result.bs = REDIS_NIL
+    # result must be nil
+    inc(pos, CRLF_LEN)
   elif bulklen == 0:
+    result = RedisValue(kind:vkBulkStr)
     inc(pos, CRLF_LEN)
   else:
-    result.bs = newString(bulklen)
+    result = RedisValue(
+      kind: vkBulkStr,
+      bs: newString(bulklen)
+    )
     for i in 0..<bulklen:
       result.bs[i] = s[pos + i]
     inc(pos, bulklen + CRLF_LEN)
@@ -117,17 +214,19 @@ proc decodeInt(s: string, pos: var int): RedisValue =
   result = RedisValue(kind:vkInt, i: ival)
   pos = crlfPos + CRLF_LEN
 
-proc decode(s: string, pos: var int): RedisValue
+proc decode(s: string, pos: var int): RedisValue {.gcsafe.}
 proc decodeArray(s: string, pos: var int): RedisValue =
   var
     crlfPos = s.find(CRLF, pos)
     arrLen = parseInt(s[pos..<crlfPos])
-
-  result = RedisValue(kind:vkArray)
   if arrLen == -1:
+    # result must be nil
     pos = crlfPos + CRLF_LEN
   else:
-    result.l = newSeq[RedisValue](arrLen)
+    result = RedisValue(
+      kind: vkArray,
+      l: newSeq[RedisValue](arrLen)
+    )
     pos = s.find(CRLF, crlfPos) + CRLF_LEN # next obj pos
 
     var i = 0
@@ -136,6 +235,8 @@ proc decodeArray(s: string, pos: var int): RedisValue =
       inc(i)
 
 proc decode(s: string, pos: var int): RedisValue =
+  if s.len == 0:
+    return nil
   let c = s[pos]
   inc(pos)
   case c
@@ -150,7 +251,8 @@ proc decode(s: string, pos: var int): RedisValue =
   of '*':
     return decodeArray(s, pos)
   else:
-    raise newException(ValueError, fmt"Unreognized char {repr c}")
+    let raw = s.multiReplace(@[("\r", "\\r"), ("\n", "\\n")])
+    raise newException(RespError, fmt"Unrecognized char {repr c} at pos {pos} in '{raw}'")
 
 const encodeValue* = encode
 proc decodeString*(resp: string): RedisValue =

--- a/src/redisparser.nim
+++ b/src/redisparser.nim
@@ -36,23 +36,24 @@ proc hash*(obj: RedisValue): Hash =
 proc `==`* (a, b: RedisValue): bool =
   ## Check two nodes for equality
   if a.isNil:
-      if b.isNil: return true
-      return false
+    if b.isNil: return true
+    return false
   elif b.isNil or a.kind != b.kind:
-      return false
+    return false
   else:
-      case a.kind
-      of vkStr:
-          result = a.s == b.s
-      of vkBulkStr:
-          result = a.bs == b.bs
-      of vkInt:
-          result = a.i == b.i
-      of vkArray:
-          result = a.l == b.l
-          result = true
-      of vkError:
-          result = a.err == b.err
+    case a.kind
+    of vkStr:
+      return a.s == b.s
+    of vkBulkStr:
+      return a.bs == b.bs
+    of vkInt:
+      return a.i == b.i
+    of vkArray:
+      return a.l == b.l
+    of vkError:
+      return a.err == b.err
+
+
 
 proc encode*(v: RedisValue) : string
 proc encodeStr(v: RedisValue) : string =

--- a/tests/testrespparser.nim
+++ b/tests/testrespparser.nim
@@ -2,11 +2,11 @@ import redisparser, tables
 
 
 var testpairs = initOrderedTable[RedisValue, string]()
-testpairs[RedisValue(kind:vkStr, s:"Hello, World")] = "+Hello, World\r\n"
-testpairs[RedisValue(kind:vkInt, i:341)] = ":341\r\n"
-testpairs[RedisValue(kind:vkError, err:"Not found")] = "-Not found\r\n"
-testpairs[RedisValue(kind:vkArray, l: @[RedisValue(kind:vkStr, s:"Hello World"), RedisValue(kind:vkInt, i:23)])] = "*2\r\n+Hello World\r\n:23\r\n\r\n"
-testpairs[RedisValue(kind:vkBulkStr, bs:"Hello, World THIS IS REALLY NICE")] = "$32\r\nHello, World THIS IS REALLY NICE\r\n"
+testpairs[newRedisString("Hello, World")] = "+Hello, World\r\n"
+testpairs[newRedisInt(341)] = ":341\r\n"
+testpairs[newRedisError("Not found")] = "-Not found\r\n"
+testpairs[newRedisArray(@[newRedisString("Hello World"), newRedisInt(23)])] = "*2\r\n+Hello World\r\n:23\r\n\r\n"
+testpairs[newRedisBulkString("Hello, World THIS IS REALLY NICE")] = "$32\r\nHello, World THIS IS REALLY NICE\r\n"
 
 
 # echo $encodeValue(RedisValue(kind:vkStr, s:"Hello, World"))
@@ -48,3 +48,4 @@ for k, v in testpairs.pairs():
 echo decodeString("*14\r\n$6\r\nlength\r\n:1\r\n$15\r\nradix-tree-keys\r\n:1\r\n$16\r\nradix-tree-nodes\r\n:2\r\n$17\r\nlast-generated-id\r\n$15\r\n1631073404886-0\r\n$6\r\ngroups\r\n:0\r\n$11\r\nfirst-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$10\r\nlast-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
 echo decodeString("*2\r\n*2\r\n$15\r\n1631095633882-0\r\n*2\r\n$4\r\nitem\r\n$1\r\n0\r\n*2\r\n$15\r\n1631095635235-0\r\n*2\r\n$4\r\nitem\r\n$1\r\n0\r\n")
 echo decodeString("*2\r\n$-1\r\n\r\n*2\r\n$15\r\n1631096564062-1\r\n*2\r\n$4\r\nitem\r\n$1\r\n0")
+echo decodeString("*4\r\n:0\r\n$-1\r\n\r\n$-1\r\n\r\n*-1\r\n")

--- a/tests/testrespparser.nim
+++ b/tests/testrespparser.nim
@@ -45,4 +45,6 @@ for k, v in testpairs.pairs():
     doAssert encodeValue(k) == v
     doAssert decodeString(v) == k
 
-#echo decodeString("*14\r\n$6\r\nlength\r\n:1\r\n$15\r\nradix-tree-keys\r\n:1\r\n$16\r\nradix-tree-nodes\r\n:2\r\n$17\r\nlast-generated-id\r\n$15\r\n1631073404886-0\r\n$6\r\ngroups\r\n:0\r\n$11\r\nfirst-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$10\r\nlast-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
+echo decodeString("*14\r\n$6\r\nlength\r\n:1\r\n$15\r\nradix-tree-keys\r\n:1\r\n$16\r\nradix-tree-nodes\r\n:2\r\n$17\r\nlast-generated-id\r\n$15\r\n1631073404886-0\r\n$6\r\ngroups\r\n:0\r\n$11\r\nfirst-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$10\r\nlast-entry\r\n*2\r\n$15\r\n1631073404886-0\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
+echo decodeString("*2\r\n*2\r\n$15\r\n1631095633882-0\r\n*2\r\n$4\r\nitem\r\n$1\r\n0\r\n*2\r\n$15\r\n1631095635235-0\r\n*2\r\n$4\r\nitem\r\n$1\r\n0\r\n")
+echo decodeString("*2\r\n$-1\r\n\r\n*2\r\n$15\r\n1631096564062-1\r\n*2\r\n$4\r\nitem\r\n$1\r\n0")


### PR DESCRIPTION
This PR is a breaking change, and not backward compatible.  Internal values are hidden, only accessible via getters for runtime type safety checks
- Bulk string and array can be nil, not just an emtpy string/array
- Runtime type checking to prevent devs accidently access  wrong value type

I am understanding  this  is a big deal, and not expect that you will approve this PR. Its up to you!